### PR TITLE
Added a pre-processor macro to check SSL version (for DH)

### DIFF
--- a/proton-c/src/ssl/openssl.c
+++ b/proton-c/src/ssl/openssl.c
@@ -403,9 +403,15 @@ static DH *get_dh2048(void)
   DH *dh;
 
   if ((dh=DH_new()) == NULL) return(NULL);
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
   dh->p=BN_bin2bn(dh2048_p,sizeof(dh2048_p),NULL);
   dh->g=BN_bin2bn(dh2048_g,sizeof(dh2048_g),NULL);
   if ((dh->p == NULL) || (dh->g == NULL))
+#else
+  BIGNUM * const dh_p = BN_bin2bn(dh2048_p,sizeof(dh2048_p), NULL);
+  BIGNUM * const dh_g = BN_bin2bn(dh2048_g,sizeof(dh2048_g), NULL);
+  if ((dh_p == NULL) || (dh_g == NULL))
+#endif
     { DH_free(dh); return(NULL); }
   return(dh);
 }


### PR DESCRIPTION
This will add support for OpenSSL 1.1, since "the DH structure is now opaque, so the parameters must be stored there through an accessor function." (https://github.com/rakshasa/libtorrent/files/663302/0001-Fix-the-DH-parameters-generation-with-OpenSSL-1.1.patch.txt) found here https://github.com/rakshasa/libtorrent/issues/138
Due to the pre-processor macro it will still be compatible with SSL 1.0